### PR TITLE
Include requirements.txt in sdist.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include octoprint_netconnectd/static *
 recursive-include octoprint_netconnectd/templates *
+include requirements.txt


### PR DESCRIPTION
If setup.py is going to depend on requirements.txt, then leaving requirements.txt out of the sdist breaks things (including downstream packaging).
