### PR TITLE
Remove deprecated use of Exception.message.

### DIFF
--- a/octoprint_netconnectd/__init__.py
+++ b/octoprint_netconnectd/__init__.py
@@ -72,7 +72,7 @@ class NetconnectdSettingsPlugin(octoprint.plugin.SettingsPlugin,
 			wifis = self._get_wifi_list()
 			status = self._get_status()
 		except Exception as e:
-			return jsonify(dict(error=e.message))
+			return jsonify(dict(error=str(e)))
 
 		return jsonify(dict(
 			wifis=wifis,
@@ -217,7 +217,7 @@ class NetconnectdSettingsPlugin(octoprint.plugin.SettingsPlugin,
 				return False, output
 
 		except Exception as e:
-			output = "Error while talking to netconnectd: {}".format(e.message)
+			output = "Error while talking to netconnectd: {}".format(e)
 			self._logger.warn(output)
 			return False, output
 


### PR DESCRIPTION
This removes some minor log spam:

```
Jun 17 01:41:23 localhost octoprint[306]: 2015-06-17 01:41:23,770 - py.warnings - WARNING - /usr/lib/python2.7/dist-packages/octoprint_netconnectd/__init__.py:75: DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
```

This is also good future-proofing for python 3.x.
