### PR TITLE
Show quality in dBm with correct sort

### DIFF
--- a/octoprint_netconnectd/static/js/netconnectd.js
+++ b/octoprint_netconnectd/static/js/netconnectd.js
@@ -151,9 +151,6 @@ $(function() {
                 var qualityInt = parseInt(wifi.quality);
                 var quality = undefined;
                 if (!isNaN(qualityInt)) {
-                    if (qualityInt <= 0) {
-                        qualityInt = (-1) * qualityInt;
-                    }
                     quality = qualityInt;
                 }
 
@@ -162,7 +159,7 @@ $(function() {
                     address: wifi.address,
                     encrypted: wifi.encrypted,
                     quality: quality,
-                    qualityText: (quality != undefined) ? "" + quality + "%" : undefined
+                    qualityText: (quality != undefined) ? "" + quality + " dBm" : undefined
                 });
             });
 


### PR DESCRIPTION
Showing quality in % result in bad sort order. I think is better display quality in dBm. Then, sort magically is now correct.